### PR TITLE
TemX Initialize Size Correction 

### DIFF
--- a/nonRigidICP.h
+++ b/nonRigidICP.h
@@ -489,7 +489,7 @@ public:
 			
 			
 			//temporal X
-			Eigen::MatrixX3d TmpX(3,4*n);
+			Eigen::MatrixX3d TmpX(4*n,3);
 			TmpX=X;
 			
 


### PR DESCRIPTION
## TemX Initialize Size Correction 
After switching `CMAKE_BUILD_TYPE `to `DEBUG`, I found Matrix `TemX` initialization fails.
Matrix `TemX` 's size should be exactly the same as `X` which is `(4n*3)` 
